### PR TITLE
Allow blank Content-Type

### DIFF
--- a/api.go
+++ b/api.go
@@ -42,7 +42,7 @@ func Request(method string, url string, opts Options) (*Response, error) {
 
 	body = nil
 	if opts.ReqBody != nil {
-		if contentType == "" {
+		if contentType == "" && !opts.OmitContentType {
 			contentType = "application/json"
 		}
 

--- a/api.go
+++ b/api.go
@@ -232,20 +232,24 @@ func Put(url string, opts Options) error {
 // SetHeaders allows the caller to provide code to set any custom headers programmatically.  Typically, this
 // facility can invoke, e.g., SetBasicAuth() on the request to easily set up authentication.
 // Any error generated will terminate the request and will propegate back to the caller.
+//
+// OmitContentType allows the caller to explicitly omit the content-type header, even if a request
+// body is provided.
 type Options struct {
-	CustomClient  *http.Client
-	ReqBody       interface{}
-	Results       interface{}
-	MoreHeaders   map[string]string
-	OkCodes       []int
-	StatusCode    *int    `DEPRECATED`
-	DumpReqJson   bool    `UNSUPPORTED`
-	ResponseJson  *[]byte `DEPRECATED`
-	Response      **Response
-	ContentType   string `json:"Content-Type,omitempty"`
-	ContentLength int64  `json:"Content-Length,omitempty"`
-	Accept        string `json:"Accept,omitempty"`
-	SetHeaders    func(r *http.Request) error
+	CustomClient    *http.Client
+	ReqBody         interface{}
+	Results         interface{}
+	MoreHeaders     map[string]string
+	OkCodes         []int
+	StatusCode      *int    `DEPRECATED`
+	DumpReqJson     bool    `UNSUPPORTED`
+	ResponseJson    *[]byte `DEPRECATED`
+	Response        **Response
+	ContentType     string `json:"Content-Type,omitempty"`
+	ContentLength   int64  `json:"Content-Length,omitempty"`
+	Accept          string `json:"Accept,omitempty"`
+	SetHeaders      func(r *http.Request) error
+	OmitContentType bool
 }
 
 // Response contains return values from the various request calls.

--- a/api_test.go
+++ b/api_test.go
@@ -257,18 +257,6 @@ func TestInferContentType(t *testing.T) {
 		t.Errorf("Expected text/plain, but was [%s]", contentType)
 	}
 
-	// It should work if the content type is provided in MoreHeaders, too.
-	_, err = Request("GET", ts.URL, Options{
-		ReqBody:     strings.NewReader("wat"),
-		MoreHeaders: map[string]string{"Content-Type": "text/plain"},
-	})
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-	if contentType := h.Get("Content-Type"); contentType != "text/plain" {
-		t.Errorf("Expected text/plain, but was [%s]", contentType)
-	}
-
 	// If explicitly told to do so, leave content-type blank
 	_, err = Request("GET", ts.URL, Options{
 		ReqBody:         strings.NewReader("wat"),

--- a/api_test.go
+++ b/api_test.go
@@ -121,15 +121,15 @@ func TestCustomHeaders(t *testing.T) {
 	}
 
 	if contentType != "x-application/vb" {
-		t.Fatalf("I expected x-application/vb; got ", contentType)
+		t.Fatalf("I expected x-application/vb; got %v", contentType)
 	}
 
 	if contentLength != "5" {
-		t.Fatalf("I expected 5 byte content length; got ", contentLength)
+		t.Fatalf("I expected 5 byte content length; got %v", contentLength)
 	}
 
 	if accept != "x-application/c" {
-		t.Fatalf("I expected x-application/c; got ", accept)
+		t.Fatalf("I expected x-application/c; got %v", accept)
 	}
 }
 
@@ -217,10 +217,67 @@ func TestBodilessMethodsAreSentWithoutContentHeaders(t *testing.T) {
 	}
 
 	if len(h["Content-Type"]) != 0 {
-		t.Fatalf("I expected nothing for Content-Type but got ", h["Content-Type"])
+		t.Fatalf("I expected nothing for Content-Type but got %v", h["Content-Type"])
 	}
 
 	if len(h["Content-Length"]) != 0 {
-		t.Fatalf("I expected nothing for Content-Length but got ", h["Content-Length"])
+		t.Fatalf("I expected nothing for Content-Length but got %v", h["Content-Length"])
+	}
+}
+
+func TestInferContentType(t *testing.T) {
+	var h http.Header
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h = r.Header
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// By default, the content-type defaults to application/json when a ReqBody is provided.
+	_, err := Request("GET", ts.URL, Options{
+		ReqBody: map[string]string{"key": "value"},
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if contentType := h.Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Expected application/json, but was [%s]", contentType)
+	}
+
+	// If a content type is specified explicitly by ContentType, that should be used instead.
+	_, err = Request("GET", ts.URL, Options{
+		ReqBody:     strings.NewReader("wat"),
+		ContentType: "text/plain",
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if contentType := h.Get("Content-Type"); contentType != "text/plain" {
+		t.Errorf("Expected text/plain, but was [%s]", contentType)
+	}
+
+	// It should work if the content type is provided in MoreHeaders, too.
+	_, err = Request("GET", ts.URL, Options{
+		ReqBody:     strings.NewReader("wat"),
+		MoreHeaders: map[string]string{"Content-Type": "text/plain"},
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if contentType := h.Get("Content-Type"); contentType != "text/plain" {
+		t.Errorf("Expected text/plain, but was [%s]", contentType)
+	}
+
+	// If explicitly told to do so, leave content-type blank
+	_, err = Request("GET", ts.URL, Options{
+		ReqBody:         strings.NewReader("wat"),
+		OmitContentType: true,
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if contentType := h.Get("Content-Type"); contentType != "" {
+		t.Errorf("Expected blank content type, but was [%s]", contentType)
 	}
 }


### PR DESCRIPTION
If `opts.ContentType` is unspecified, the current behavior is to default to `application/json` and attempt to marshal the `ReqBody` as a JSON object. Unfortunately, this means that there's no way to explicilty send a request with a body, but no Content-Type. It's a bit of an edge case, but we hit it in rackspace/gophercloud#336.

This allows the caller to set an `OmitContentType` flag on the request options to explicitly omit a content-type header if none is provided.